### PR TITLE
Fix chat vulnerability

### DIFF
--- a/index.js
+++ b/index.js
@@ -202,7 +202,7 @@ stream.on('tweet', function (tweet) {
 ///***Server Setup***//////////////////////////////////////////////
 
 http.listen(process.env.PORT || 3000, function(){
-	console.log("Twitter Lounge is listening on port " + process.env.PORT || 3000);
+	console.log("Twitter Lounge is listening on port " + (process.env.PORT || 3000));
 });
 
 

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -21,7 +21,7 @@ $(function(){
 	});
 //take chat messages broadcast from server and render them///
 	socket.on('chat message', function(msg){
-		$('#messages').prepend($('<li>').html(msg));
+		$('#messages').prepend($('<li>').text(msg));
 		var ding = new Audio('static/tim_tum.mp3');
 		ding.volume = 0.75;
 		ding.play();


### PR DESCRIPTION
Changing "html" to "text" when chat lines prepend stopped the site from using the input scripts.
